### PR TITLE
Escape square brackets in `quant_dir_regex`.

### DIFF
--- a/src/w90utils/io/win.py
+++ b/src/w90utils/io/win.py
@@ -59,7 +59,7 @@ spinors_regex = re.compile(
     re.VERBOSE | re.IGNORECASE | re.DOTALL
     )
 spin_regex = re.compile(r'[(](?P<up>u)?,?(?P<dn>d)?[)]')
-quant_dir_regex = re.compile(r'[[](?P<quant_dir>.+)[]]$')
+quant_dir_regex = re.compile(r'[\[](?P<quant_dir>.+)[\]]$')
 
 
 def remove_comments(s):

--- a/src/w90utils/io/win.py
+++ b/src/w90utils/io/win.py
@@ -55,7 +55,7 @@ proj_line_regex = re.compile(
     )
 
 spinors_regex = re.compile(
-    'spinors\s+=\s+(T|.TRUE.)',
+    r'spinors\s+=\s+(T|.TRUE.)',
     re.VERBOSE | re.IGNORECASE | re.DOTALL
     )
 spin_regex = re.compile(r'[(](?P<up>u)?,?(?P<dn>d)?[)]')
@@ -194,8 +194,8 @@ def read_proj_line(line, dlv, basis, spinors):
                         orbitals_lmr.append((l, i))
             else:
                 orbitals_lmr.append((l, mr))
-        elif re.compile('l=(?P<l>[-]?\d),?(mr=(?P<mr>(\d,?)+))?').match(orbital):
-            match = re.compile('l=(?P<l>[-]?\d),?(mr=(?P<mr>(\d,?)+))?').match(orbital)
+        elif re.compile(r'l=(?P<l>[-]?\d),?(mr=(?P<mr>(\d,?)+))?').match(orbital):
+            match = re.compile(r'l=(?P<l>[-]?\d),?(mr=(?P<mr>(\d,?)+))?').match(orbital)
             for mr in match.group('mr').split(','):
                 orbitals_lmr.append((int(match.group('l')), int(mr)))
         else:


### PR DESCRIPTION
From Python 3.7, regex syntax that could be interpreted as nested
sets raises a `FutureWarning`[1,2].

This commit escapes the literal `[` and `]` in `quant_dir_regex`
to get rid of this warning.

[1] https://bugs.python.org/issue30349
[2] https://docs.python.org/dev/whatsnew/3.7.html#re